### PR TITLE
Separate build and archive commands in Xamarin builder

### DIFF
--- a/xamarin-builder/analyzer.rb
+++ b/xamarin-builder/analyzer.rb
@@ -100,11 +100,19 @@ class Analyzer
 
           build_commands << [
               MDTOOL_PATH,
-              generate_archive ? 'archive' : 'build',
+              'build',
               "\"-c:#{mdtool_configuration(project_configuration)}\"",
               "\"#{@solution[:path]}\"",
               "\"-p:#{project[:name]}\""
           ].join(' ')
+
+          build_commands << [
+              MDTOOL_PATH,
+              'archive',
+              "\"-c:#{mdtool_configuration(project_configuration)}\"",
+              "\"#{@solution[:path]}\"",
+              "\"-p:#{project[:name]}\""
+          ].join(' ') if generate_archive
         when 'android'
           next unless project_type_filter.include? 'android'
           next unless project[:android_application]


### PR DESCRIPTION
Calls to `mdtool archive` utility should be preceded by `mdtool build` otherwise archive step will fail.

This fix was tested locally. Please review the following build log for more details:
https://gist.github.com/olegoid/bf67332197daca346aed905c859ca4df
