### PR TITLE
Xamarin mac support + refactoring

### DIFF
--- a/generate_export_options.rb
+++ b/generate_export_options.rb
@@ -107,7 +107,10 @@ export_options = {}
 export_options[:method] = method unless method.nil?
 
 # explicitly set this option to false for Xamarin.Mac projects since they have no support of dSYMs
-export_options[:uploadSymbols] = 'NO' if options[:target_os].eql?(Api::MAC)
+if options[:target_os].eql?(Api::MAC)
+  export_options[:uploadSymbols] = 'NO'
+  puts "Warning: Skipping dSYMs upload not supported by Xamarin.Mac OS projects"
+end
 
 puts
 puts "\e[34mCreating export options for export type: #{export_options[:method]}\e[0m"

--- a/step.yml
+++ b/step.yml
@@ -32,7 +32,7 @@ inputs:
       description: |
         Xamarin platform
       is_required: true
-  - platform_filter: "ios,android"
+  - platform_filter: "ios,android,mac"
     opts:
       title: "Platform filter"
       description: |
@@ -42,7 +42,10 @@ inputs:
       value_options:
       - "ios"
       - "android"
+      - "mac"
       - "ios,android"
+      - "ios,mac"
+      - "android,mac"
   - export_options_path:
     opts:
       title: "Export options path"

--- a/step.yml
+++ b/step.yml
@@ -46,6 +46,7 @@ inputs:
       - "ios,android"
       - "ios,mac"
       - "android,mac"
+      - "ios,android,mac"
   - export_options_path:
     opts:
       title: "Export options path"

--- a/xamarin-builder/analyzer.rb
+++ b/xamarin-builder/analyzer.rb
@@ -52,6 +52,10 @@ REGEX_PROJECT_ANDROID_PACKAGE_NAME = /<manifest.*package=\"(?<package_name>.*)\"
 REGEX_PROJECT_ANDROID_APPLICATION= /<AndroidApplication>True<\/AndroidApplication>/i
 REGEX_PROJECT_SIGN_ANDROID = /<AndroidKeyStore>True<\/AndroidKeyStore>/i
 
+#
+# Assembly references
+REGEX_PROJECT_REFERENCE_XAMARIN_UITEST = /Include="Xamarin.UITest"/i
+
 REGEX_ARCHIVE_DATE_TIME = /\s(.*[AM]|[PM]).*\./i
 
 class Analyzer
@@ -59,8 +63,7 @@ class Analyzer
       ios: "FEACFBD2-3405-455C-9665-78FE426C6842",
       mac: "A3F8F2AB-B479-4A4A-A458-A89E7DC349F1",
       tvos: "06FA79CB-D6CD-4721-BB4B-1BD202089C55",
-      android: "EFBA0AD7-5A72-4C68-AF49-83D382785DCF",
-      uitest: "B2E420A5-F7CC-4D22-B6E3-8F1FFD782A31"
+      android: "EFBA0AD7-5A72-4C68-AF49-83D382785DCF"
   }
 
   class << self
@@ -452,6 +455,11 @@ class Analyzer
       match = line.match(REGEX_PROJECT_TYPE_GUIDS)
       project[:api] = identify_project_api(match.captures.first) if match != nil && match.captures != nil && match.captures.count == 1
 
+      if project[:api].nil?
+        match = line.match(REGEX_PROJECT_REFERENCE_XAMARIN_UITEST)
+        (project[:api] ||= []) << Api::UITEST if match != nil
+      end
+
       # Referred projects
       match = line.match(REGEX_PROJECT_PROJECT_REFERENCE_END)
       referred_project_paths = nil if match
@@ -487,10 +495,10 @@ class Analyzer
       Api::ANDROID
     elsif project_type_guids.include? Analyzer.project_type_guids[:mac]
       Api::MAC
-    elsif project_type_guids.include? Analyzer.project_type_guids[:uitest]
-      Api::UITEST
     elsif project_type_guids.include? Analyzer.project_type_guids[:tvos]
       Api::TVOS
+    else
+      nil
     end
   end
 

--- a/xamarin-builder/api.rb
+++ b/xamarin-builder/api.rb
@@ -1,0 +1,7 @@
+module Api
+  IOS = 'ios' # Xamarin.iOS projects
+  MAC = 'mac' # Xamarin.Mac projects
+  TVOS = 'tvos' # Xamarin.TVOS projects
+  ANDROID = 'android' # Xamarin.Android projects
+  UITEST = 'uitest' # Xamarin.UITest projects
+end

--- a/xamarin-builder/builder.rb
+++ b/xamarin-builder/builder.rb
@@ -12,7 +12,7 @@ class Builder
     @path = path
     @configuration = configuration
     @platform = platform
-    @project_type_filter = project_type_filter || [Api::IOS, Api::ANDROID, Api::Mac]
+    @project_type_filter = project_type_filter || [Api::IOS, Api::ANDROID, Api::MAC]
 
     @analyzer = Analyzer.new
     @analyzer.analyze(@path)


### PR DESCRIPTION
This PR brings the following features to xamarin-builder step:
- Xamarin.Mac projects support
- F# projects support
- New approach of project type detection: use project type guids instead of referenced libraries
